### PR TITLE
Feature/Ignored files (blacklist)

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,11 +17,11 @@ all available * .properties files from a root directory and imports the path and
         (ci)check-integrity [L]:                Check if all SRC properties provided by XLS properties with all or specified languages(all or by language ISOCODE[L]).
         (cl)ear-loc:                            Delete all(!) entries for Localization!
         (f)iles DIR:                            Read recursive down for properties files and save fileinfo.
-        (iil)import-ignored-list:               Import list of files that are to be excluded from the translation process.
+        (iil)import-ignore-list:                Import list of files that are to be excluded from the translation process.
+        (cil)clear-ignore-list:                 Clear list with ignored files.
         command options mandatory:              Command parameters without brackets are mandatory
         command options optional:               Command parameters inside brackets are optional
         (h)elp:                                 Print this!
-
 
 ### Requirements:
 

--- a/README.md
+++ b/README.md
@@ -17,6 +17,7 @@ all available * .properties files from a root directory and imports the path and
         (ci)check-integrity [L]:                Check if all SRC properties provided by XLS properties with all or specified languages(all or by language ISOCODE[L]).
         (cl)ear-loc:                            Delete all(!) entries for Localization!
         (f)iles DIR:                            Read recursive down for properties files and save fileinfo.
+        (iil)import-ignored-list:               Import list of files that are to be excluded from the translation process.
         command options mandatory:              Command parameters without brackets are mandatory
         command options optional:               Command parameters inside brackets are optional
         (h)elp:                                 Print this!

--- a/src/main/java/de/aspera/locapp/cmd/ClearIgnoreListCommand.java
+++ b/src/main/java/de/aspera/locapp/cmd/ClearIgnoreListCommand.java
@@ -1,0 +1,21 @@
+package de.aspera.locapp.cmd;
+
+import java.util.logging.Level;
+import java.util.logging.Logger;
+
+import de.aspera.locapp.dao.DatabaseException;
+import de.aspera.locapp.dao.IgnoredItemFacade;
+
+public class ClearIgnoreListCommand implements CommandRunnable {
+    private static final Logger logger = Logger.getLogger(ClearIgnoreListCommand.class.getName());
+
+    @Override
+    public void run() {
+        try {
+            new IgnoredItemFacade().removeAll();
+            logger.log(Level.INFO, "The ignore list has been cleared.");
+        } catch (DatabaseException e) {
+            logger.severe(e.getMessage());
+        }
+    }
+}

--- a/src/main/java/de/aspera/locapp/cmd/ClearIgnoreListCommand.java
+++ b/src/main/java/de/aspera/locapp/cmd/ClearIgnoreListCommand.java
@@ -13,7 +13,7 @@ public class ClearIgnoreListCommand implements CommandRunnable {
     public void run() {
         try {
             new IgnoredItemFacade().removeAll();
-            logger.log(Level.INFO, "The ignore list has been cleared.");
+            logger.log(Level.INFO, "All IgnoredItem entries were deleted!");
         } catch (DatabaseException e) {
             logger.severe(e.getMessage());
         }

--- a/src/main/java/de/aspera/locapp/cmd/CommandContext.java
+++ b/src/main/java/de/aspera/locapp/cmd/CommandContext.java
@@ -23,8 +23,12 @@ public class CommandContext {
     private CommandContext() {
     }
 
-    public void executeCommand(String command) throws CommandException, InstantiationException, IllegalAccessException {
-        ((CommandRunnable) commandMap.get(command).newInstance()).run();
+    public void executeCommand(String command) throws CommandException {
+        try {
+			((CommandRunnable) commandMap.get(command).getDeclaredConstructor().newInstance()).run();
+		} catch (Exception  e) {
+			throw new CommandException(e.getMessage(), e);
+		}
         clearArguments();
     }
 

--- a/src/main/java/de/aspera/locapp/cmd/CommandContext.java
+++ b/src/main/java/de/aspera/locapp/cmd/CommandContext.java
@@ -93,6 +93,8 @@ public class CommandContext {
         addCommand("ci", CheckIntegrityCommand.class);
         addCommand("check-integrity", CheckIntegrityCommand.class);
         addCommand("iil", ImportIgnoredItemsCommand.class);
-        addCommand("import-ignored-list", ImportIgnoredItemsCommand.class);
+        addCommand("import-ignore-list", ImportIgnoredItemsCommand.class);
+        addCommand("cil", ClearIgnoreListCommand.class);
+        addCommand("clear-ignore-list", ClearIgnoreListCommand.class);
     }
 }

--- a/src/main/java/de/aspera/locapp/cmd/CommandContext.java
+++ b/src/main/java/de/aspera/locapp/cmd/CommandContext.java
@@ -92,5 +92,7 @@ public class CommandContext {
         addCommand("merge-properties", MergeCommand.class);
         addCommand("ci", CheckIntegrityCommand.class);
         addCommand("check-integrity", CheckIntegrityCommand.class);
+        addCommand("iil", ImportIgnoredItemsCommand.class);
+        addCommand("import-ignored-list", ImportIgnoredItemsCommand.class);
     }
 }

--- a/src/main/java/de/aspera/locapp/cmd/FilesCommand.java
+++ b/src/main/java/de/aspera/locapp/cmd/FilesCommand.java
@@ -12,7 +12,6 @@ import org.apache.commons.lang3.SystemUtils;
 import de.aspera.locapp.dao.ConfigFacade;
 import de.aspera.locapp.dao.DatabaseException;
 import de.aspera.locapp.dao.FileInfoFacade;
-import de.aspera.locapp.dao.IgnoredItemFacade;
 import de.aspera.locapp.dto.FileInfo;
 
 public class FilesCommand implements CommandRunnable {

--- a/src/main/java/de/aspera/locapp/cmd/FilesCommand.java
+++ b/src/main/java/de/aspera/locapp/cmd/FilesCommand.java
@@ -3,7 +3,6 @@ package de.aspera.locapp.cmd;
 import java.io.File;
 import java.util.ArrayList;
 import java.util.List;
-import java.util.Set;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 
@@ -33,9 +32,7 @@ public class FilesCommand implements CommandRunnable {
 
         long start = System.currentTimeMillis();
         ConfigFacade configFacade = new ConfigFacade();
-        IgnoredItemFacade ignoredItemFacade = new IgnoredItemFacade();
-        Set<String> ignoredFileNames =  ignoredItemFacade.listIgnoredFileNames();
-
+        
         String[] excludedPaths = new String[] { "" };
         try {
             excludedPaths = configFacade.getValue("Excluded_Paths");

--- a/src/main/java/de/aspera/locapp/cmd/FilesCommand.java
+++ b/src/main/java/de/aspera/locapp/cmd/FilesCommand.java
@@ -3,6 +3,7 @@ package de.aspera.locapp.cmd;
 import java.io.File;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Set;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 
@@ -33,6 +34,7 @@ public class FilesCommand implements CommandRunnable {
         long start = System.currentTimeMillis();
         ConfigFacade configFacade = new ConfigFacade();
         IgnoredItemFacade ignoredItemFacade = new IgnoredItemFacade();
+        Set<String> ignoredFileNames =  ignoredItemFacade.listIgnoredFileNames();
 
         String[] excludedPaths = new String[] { "" };
         try {
@@ -56,7 +58,7 @@ public class FilesCommand implements CommandRunnable {
                         file.getAbsolutePath().replace(path, SystemUtils.IS_OS_WINDOWS ? ".\\" : "./"));
                 fileInfo.setSearchPath(path);
 
-                if (ignoredItemFacade.isIgnored(file.getName())) {
+                if (ignoredFileNames.contains(file.getName())) {
                     logger.log(Level.INFO, "Ignoring " + file.getName());
                     continue;
                 }

--- a/src/main/java/de/aspera/locapp/cmd/FilesCommand.java
+++ b/src/main/java/de/aspera/locapp/cmd/FilesCommand.java
@@ -58,11 +58,6 @@ public class FilesCommand implements CommandRunnable {
                         file.getAbsolutePath().replace(path, SystemUtils.IS_OS_WINDOWS ? ".\\" : "./"));
                 fileInfo.setSearchPath(path);
 
-                if (ignoredFileNames.contains(file.getName())) {
-                    logger.log(Level.INFO, "Ignoring " + file.getName());
-                    continue;
-                }
-                
                 files.add(fileInfo);
             }
             fileFacade.saveFileInfos(files);

--- a/src/main/java/de/aspera/locapp/cmd/FilesCommand.java
+++ b/src/main/java/de/aspera/locapp/cmd/FilesCommand.java
@@ -12,6 +12,7 @@ import org.apache.commons.lang3.SystemUtils;
 import de.aspera.locapp.dao.ConfigFacade;
 import de.aspera.locapp.dao.DatabaseException;
 import de.aspera.locapp.dao.FileInfoFacade;
+import de.aspera.locapp.dao.IgnoredItemFacade;
 import de.aspera.locapp.dto.FileInfo;
 
 public class FilesCommand implements CommandRunnable {
@@ -31,6 +32,8 @@ public class FilesCommand implements CommandRunnable {
 
         long start = System.currentTimeMillis();
         ConfigFacade configFacade = new ConfigFacade();
+        IgnoredItemFacade ignoredItemFacade = new IgnoredItemFacade();
+
         String[] excludedPaths = new String[] { "" };
         try {
             excludedPaths = configFacade.getValue("Excluded_Paths");
@@ -52,6 +55,12 @@ public class FilesCommand implements CommandRunnable {
                 fileInfo.setRelativePath(
                         file.getAbsolutePath().replace(path, SystemUtils.IS_OS_WINDOWS ? ".\\" : "./"));
                 fileInfo.setSearchPath(path);
+
+                if (ignoredItemFacade.isIgnored(file.getName())) {
+                    logger.log(Level.INFO, "Ignoring " + file.getName());
+                    continue;
+                }
+                
                 files.add(fileInfo);
             }
             fileFacade.saveFileInfos(files);

--- a/src/main/java/de/aspera/locapp/cmd/HelpCommand.java
+++ b/src/main/java/de/aspera/locapp/cmd/HelpCommand.java
@@ -17,6 +17,7 @@ public class HelpCommand implements CommandRunnable {
         System.out.println("\t(ci)check-integrity [L]: \t\tCheck if all SRC properties provided by XLS properties with all or specified languages(all or by language ISOCODE[L]).");
         System.out.println("\t(cl)ear-loc: \t\t\t\tDelete all(!) entries for Localization!");
         System.out.println("\t(f)iles DIR: \t\t\t\tRead recursive down for properties files and save fileinfo.");
+        System.out.println("\t(iil)import-ignored-list: \t\tImport list of files that are to be excluded from the translation process.");
         System.out.println("\tcommand options mandatory: \t\tCommand parameters without brackets are mandatory");
         System.out.println("\tcommand options optional: \t\tCommand parameters inside brackets are optional\n");
         System.out.println("\t(h)elp: \t\t\t\tPrint this!\n\n");

--- a/src/main/java/de/aspera/locapp/cmd/HelpCommand.java
+++ b/src/main/java/de/aspera/locapp/cmd/HelpCommand.java
@@ -17,7 +17,8 @@ public class HelpCommand implements CommandRunnable {
         System.out.println("\t(ci)check-integrity [L]: \t\tCheck if all SRC properties provided by XLS properties with all or specified languages(all or by language ISOCODE[L]).");
         System.out.println("\t(cl)ear-loc: \t\t\t\tDelete all(!) entries for Localization!");
         System.out.println("\t(f)iles DIR: \t\t\t\tRead recursive down for properties files and save fileinfo.");
-        System.out.println("\t(iil)import-ignored-list: \t\tImport list of files that are to be excluded from the translation process.");
+        System.out.println("\t(iil)import-ignore-list: \t\tImport list of files that are to be excluded from the translation process.");
+        System.out.println("\t(cil)clear-ignore-list: \t\tClear list with ignored files.");
         System.out.println("\tcommand options mandatory: \t\tCommand parameters without brackets are mandatory");
         System.out.println("\tcommand options optional: \t\tCommand parameters inside brackets are optional\n");
         System.out.println("\t(h)elp: \t\t\t\tPrint this!\n\n");

--- a/src/main/java/de/aspera/locapp/cmd/ImportIgnoredItemsCommand.java
+++ b/src/main/java/de/aspera/locapp/cmd/ImportIgnoredItemsCommand.java
@@ -1,80 +1,71 @@
 package de.aspera.locapp.cmd;
 
-import java.io.BufferedReader;
 import java.io.File;
-import java.io.FileInputStream;
-import java.io.FileNotFoundException;
-import java.io.IOException;
-import java.io.InputStreamReader;
-import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
+import java.util.HashSet;
+import java.util.Iterator;
 import java.util.List;
-import java.util.StringTokenizer;
+import java.util.Set;
 import java.util.logging.Level;
 import java.util.logging.Logger;
-import java.util.stream.Collectors;
+
+import org.apache.commons.io.FileUtils;
 
 import de.aspera.locapp.dao.DatabaseException;
 import de.aspera.locapp.dao.IgnoredItemFacade;
 import de.aspera.locapp.dto.IgnoredItem;
 
 public class ImportIgnoredItemsCommand implements CommandRunnable {
-    private static final Logger logger = Logger.getLogger(ImportIgnoredItemsCommand.class.getName());
+	private static final Logger logger = Logger.getLogger(ImportIgnoredItemsCommand.class.getName());
 
-    private IgnoredItemFacade ignoredItemFacade = new IgnoredItemFacade();
+	private IgnoredItemFacade ignoredItemFacade = new IgnoredItemFacade();
 
-    @Override
-    public void run() {
-        var ctx = CommandContext.getInstance();
-        var ignoredItemsListPath = ctx.nextArgument();
-        var ignoredItems = readIgnoredItemsFile(ignoredItemsListPath);
+	@Override
+	public void run() {
+		var ctx = CommandContext.getInstance();
+		var ignoredItemsListPath = ctx.nextArgument();
+		var ignoredItems = readIgnoredItemsFile(ignoredItemsListPath);
+		try {
+			for (var ignoredItem : ignoredItems) {
+				ignoredItemFacade.create(ignoredItem);
+				System.out.println(" >> Add ignore entry: " + ignoredItem.getFileName() + " to be ignored on export. <<");
+			}
+			if (ignoredItems != null && ignoredItems.size() >= 0)
+				logger.log(Level.INFO, "Marked " + ignoredItems.size() + " files to be ignored.");
+		} catch (DatabaseException e) {
+			logger.log(Level.SEVERE, "Error while saving IgnoredItem entity.", e);
+			return;
+		}
+	}
 
-        try {
-            for (var ignoredItem : ignoredItems) {
-                ignoredItemFacade.create(ignoredItem);
-            }
-        } catch (DatabaseException e) {
-            logger.log(Level.SEVERE, "Error while saving IgnoredItem entity.", e);
-            return;
-        }
+	private List<IgnoredItem> readIgnoredItemsFile(String filePath) {
+		List<IgnoredItem> ignoredItems = new ArrayList<>();
+		final Set<String> linesOfFile;
+		try {
+			linesOfFile = new HashSet<>(FileUtils.readLines(new File(filePath)));
+		} catch (Exception e) {
+			logger.log(Level.WARNING, "File " + filePath + " could not found or was invalid!.");
+			return ignoredItems;
+		}
+		
+		Set<String> savedIgnoreFiles = getSavedIgnoreFiles();
+		for (Iterator<String> iterator = linesOfFile.iterator(); iterator.hasNext();) {
+			String string = (String) iterator.next();
+			if (savedIgnoreFiles.contains(string))
+				continue;
+			var item = new IgnoredItem();
+			item.setFileName(string);
+			ignoredItems.add(item);
+		}
+		return ignoredItems;
+	}
 
-        logger.log(Level.INFO, "Marked " + ignoredItems.size() + " files to be ignored.");
-    }
-
-    private List<IgnoredItem> readIgnoredItemsFile(String filePath) {
-        List<IgnoredItem> ignoredItems = new ArrayList<>();
-        File file;
-        FileInputStream inputStream;
-
-        try {
-            file = new File(filePath);
-            inputStream = new FileInputStream(file);
-        } catch (FileNotFoundException e) {
-            logger.log(Level.SEVERE, "File " + filePath + " not found.", e);
-            return ignoredItems;
-        }
-         
-        var streamReader = new InputStreamReader(inputStream, StandardCharsets.UTF_8);
-        var fileAsText = new BufferedReader(streamReader)
-            .lines()
-            .collect(Collectors.joining("\n"));
-
-        try {
-            streamReader.close();
-        } catch (IOException e) {
-            logger.log(Level.SEVERE, "Error while closing stream reader.", e);
-            return ignoredItems;
-        }
-        
-        StringTokenizer tokenizer = new StringTokenizer(fileAsText);
-        
-        while (tokenizer.hasMoreTokens()) {
-            var token = tokenizer.nextToken();
-            var item = new IgnoredItem();
-            item.setFileName(token);
-            ignoredItems.add(item);
-        }
-
-        return ignoredItems;
-    }
+	private Set<String> getSavedIgnoreFiles() {
+		List<IgnoredItem> ignored = ignoredItemFacade.findAll();
+		Set<String> knownIgnoreFiles = new HashSet<>();
+		for (IgnoredItem ignoreItem : ignored) {
+			knownIgnoreFiles.add(ignoreItem.getFileName());
+		}
+		return knownIgnoreFiles;
+	}
 }

--- a/src/main/java/de/aspera/locapp/cmd/ImportIgnoredItemsCommand.java
+++ b/src/main/java/de/aspera/locapp/cmd/ImportIgnoredItemsCommand.java
@@ -32,11 +32,13 @@ public class ImportIgnoredItemsCommand implements CommandRunnable {
         try {
             for (var ignoredItem : ignoredItems) {
                 ignoredItemFacade.create(ignoredItem);
-
             }
         } catch (DatabaseException e) {
             logger.log(Level.SEVERE, "Error while saving IgnoredItem entity.", e);
+            return;
         }
+
+        logger.log(Level.INFO, "Marked " + ignoredItems.size() + " files to be ignored.");
     }
 
     private List<IgnoredItem> readIgnoredItemsFile(String filePath) {
@@ -70,6 +72,7 @@ public class ImportIgnoredItemsCommand implements CommandRunnable {
             var token = tokenizer.nextToken();
             var item = new IgnoredItem();
             item.setFileName(token);
+            ignoredItems.add(item);
         }
 
         return ignoredItems;

--- a/src/main/java/de/aspera/locapp/cmd/ImportIgnoredItemsCommand.java
+++ b/src/main/java/de/aspera/locapp/cmd/ImportIgnoredItemsCommand.java
@@ -1,0 +1,77 @@
+package de.aspera.locapp.cmd;
+
+import java.io.BufferedReader;
+import java.io.File;
+import java.io.FileInputStream;
+import java.io.FileNotFoundException;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.nio.charset.StandardCharsets;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.StringTokenizer;
+import java.util.logging.Level;
+import java.util.logging.Logger;
+import java.util.stream.Collectors;
+
+import de.aspera.locapp.dao.DatabaseException;
+import de.aspera.locapp.dao.IgnoredItemFacade;
+import de.aspera.locapp.dto.IgnoredItem;
+
+public class ImportIgnoredItemsCommand implements CommandRunnable {
+    private static final Logger logger = Logger.getLogger(ImportIgnoredItemsCommand.class.getName());
+
+    private IgnoredItemFacade ignoredItemFacade = new IgnoredItemFacade();
+
+    @Override
+    public void run() {
+        var ctx = CommandContext.getInstance();
+        var ignoredItemsListPath = ctx.nextArgument();
+        var ignoredItems = readIgnoredItemsFile(ignoredItemsListPath);
+
+        try {
+            for (var ignoredItem : ignoredItems) {
+                ignoredItemFacade.create(ignoredItem);
+
+            }
+        } catch (DatabaseException e) {
+            logger.log(Level.SEVERE, "Error while saving IgnoredItem entity.", e);
+        }
+    }
+
+    private List<IgnoredItem> readIgnoredItemsFile(String filePath) {
+        List<IgnoredItem> ignoredItems = new ArrayList<>();
+        File file;
+        FileInputStream inputStream;
+
+        try {
+            file = new File(filePath);
+            inputStream = new FileInputStream(file);
+        } catch (FileNotFoundException e) {
+            logger.log(Level.SEVERE, "File " + filePath + " not found.", e);
+            return ignoredItems;
+        }
+         
+        var streamReader = new InputStreamReader(inputStream, StandardCharsets.UTF_8);
+        var fileAsText = new BufferedReader(streamReader)
+            .lines()
+            .collect(Collectors.joining("\n"));
+
+        try {
+            streamReader.close();
+        } catch (IOException e) {
+            logger.log(Level.SEVERE, "Error while closing stream reader.", e);
+            return ignoredItems;
+        }
+        
+        StringTokenizer tokenizer = new StringTokenizer(fileAsText);
+        
+        while (tokenizer.hasMoreTokens()) {
+            var token = tokenizer.nextToken();
+            var item = new IgnoredItem();
+            item.setFileName(token);
+        }
+
+        return ignoredItems;
+    }
+}

--- a/src/main/java/de/aspera/locapp/dao/IgnoredItemFacade.java
+++ b/src/main/java/de/aspera/locapp/dao/IgnoredItemFacade.java
@@ -1,7 +1,9 @@
 package de.aspera.locapp.dao;
 
+import java.util.Set;
 import java.util.logging.Level;
 import java.util.logging.Logger;
+import java.util.stream.Collectors;
 
 import de.aspera.locapp.dto.IgnoredItem;
 
@@ -11,22 +13,11 @@ public class IgnoredItemFacade extends AbstractFacade<IgnoredItem> {
     public IgnoredItemFacade() {
         super(IgnoredItem.class);
     }
-    
-    public boolean isIgnored(String name) {
-        if (name == null) {
-            throw new IllegalArgumentException();
-        }
 
-        try {
-            var queryStr = "select * from IgnoredItem.name where IgnoredItem.name = :name";
-            var query = getEntityManager().createQuery(queryStr);
-            query.setParameter("name", name);
-            
-            var ignoredItem = query.getResultList();
-            return ignoredItem.size() > 0;
-        } catch (Exception e) {
-            logger.log(Level.SEVERE, "Error while executing query.", e);
-            return false;
-        }
+    public Set<String> listIgnoredFileNames() {
+        return findAll()
+            .stream()
+            .map(item -> item.getFileName())
+            .collect(Collectors.toSet());
     }
 }

--- a/src/main/java/de/aspera/locapp/dao/IgnoredItemFacade.java
+++ b/src/main/java/de/aspera/locapp/dao/IgnoredItemFacade.java
@@ -1,20 +1,16 @@
 package de.aspera.locapp.dao;
 
 import java.util.Set;
-import java.util.logging.Level;
-import java.util.logging.Logger;
 import java.util.stream.Collectors;
 
 import de.aspera.locapp.dto.IgnoredItem;
 
 public class IgnoredItemFacade extends AbstractFacade<IgnoredItem> {
-    private static final Logger logger = Logger.getLogger(IgnoredItemFacade.class.getName());
-
     public IgnoredItemFacade() {
         super(IgnoredItem.class);
     }
 
-    public Set<String> listIgnoredFileNames() {
+    public Set<String> listIgnoredFiles() {
         return findAll()
             .stream()
             .map(item -> item.getFileName())

--- a/src/main/java/de/aspera/locapp/dao/IgnoredItemFacade.java
+++ b/src/main/java/de/aspera/locapp/dao/IgnoredItemFacade.java
@@ -1,0 +1,32 @@
+package de.aspera.locapp.dao;
+
+import java.util.logging.Level;
+import java.util.logging.Logger;
+
+import de.aspera.locapp.dto.IgnoredItem;
+
+public class IgnoredItemFacade extends AbstractFacade<IgnoredItem> {
+    private static final Logger logger = Logger.getLogger(IgnoredItemFacade.class.getName());
+
+    public IgnoredItemFacade() {
+        super(IgnoredItem.class);
+    }
+    
+    public boolean isIgnored(String name) {
+        if (name == null) {
+            throw new IllegalArgumentException();
+        }
+
+        try {
+            var queryStr = "select * from IgnoredItem.name where IgnoredItem.name = :name";
+            var query = getEntityManager().createQuery(queryStr);
+            query.setParameter("name", name);
+            
+            var ignoredItem = query.getResultList();
+            return ignoredItem.size() > 0;
+        } catch (Exception e) {
+            logger.log(Level.SEVERE, "Error while executing query.", e);
+            return false;
+        }
+    }
+}

--- a/src/main/java/de/aspera/locapp/dao/LocalizationFacade.java
+++ b/src/main/java/de/aspera/locapp/dao/LocalizationFacade.java
@@ -77,7 +77,7 @@ public class LocalizationFacade extends AbstractFacade<Localization> {
 
     public List<String> getLanguages(boolean exportProperties, boolean appendSkipped) throws DatabaseException {
         try {
-            String queryStr = "select distinct target.locale, target.fileName from " + Localization.class.getSimpleName() + " target ";
+            String queryStr = "select distinct target.locale, target.fullPath from " + Localization.class.getSimpleName() + " target ";
             if (exportProperties) {
             	queryStr += " where target.status = :status AND target.version = :version";
             }
@@ -87,15 +87,15 @@ public class LocalizationFacade extends AbstractFacade<Localization> {
             	query.setParameter("status", Status.XLS);
             }
 
-            final Set<String> ignoredFileNames = appendSkipped
+            final Set<String> ignoredFiles = appendSkipped
                 ? new HashSet<String>()
-                : ignoredItemFacade.listIgnoredFileNames();
+                : ignoredItemFacade.listIgnoredFiles();
 
             @SuppressWarnings("unchecked")
             var languages = (List<Object[]>)query.getResultList();
 
             return languages.stream()
-                .filter(row -> !ignoredFileNames.contains((String)(row[1])))
+                .filter(row -> !HelperUtil.isIgnoredFile(ignoredFiles, (String)(row[1])))
                 .map(row -> (String)(row[0]))
                 .collect(Collectors.toList());
         } catch (Exception e) {
@@ -134,11 +134,10 @@ public class LocalizationFacade extends AbstractFacade<Localization> {
                 return locs;
             }
 
-            Set<String> ignoredFileNames = ignoredItemFacade.listIgnoredFileNames();
+            Set<String> ignoredFiles = ignoredItemFacade.listIgnoredFiles();
             return locs.stream()
-                .filter(loc -> !ignoredFileNames.contains(loc.getFileName()))
+                .filter(loc -> !HelperUtil.isIgnoredFile(ignoredFiles, loc.getFullPath()))
                 .collect(Collectors.toList());
-            
         } catch (Exception e) {
             throw new DatabaseException(e.getMessage(), e);
         }

--- a/src/main/java/de/aspera/locapp/dao/LocalizationFacade.java
+++ b/src/main/java/de/aspera/locapp/dao/LocalizationFacade.java
@@ -106,6 +106,7 @@ public class LocalizationFacade extends AbstractFacade<Localization> {
 
             return procLanguages.stream()
                 .map(row -> (String)(row[0]))
+                .distinct()
                 .collect(Collectors.toList());
         } catch (Exception e) {
             throw new DatabaseException(e.getMessage(), e);

--- a/src/main/java/de/aspera/locapp/dto/IgnoredItem.java
+++ b/src/main/java/de/aspera/locapp/dto/IgnoredItem.java
@@ -9,6 +9,7 @@ import javax.persistence.Id;
 import javax.persistence.Table;
 import javax.persistence.UniqueConstraint;
 
+
 @Entity
 @Table(
     name = "IGNORED_ITEM",
@@ -37,5 +38,31 @@ public class IgnoredItem implements Serializable {
 
     public void setFileName(String fileName) {
         this.fileName = fileName;
+    }
+
+    @Override
+    public int hashCode() {
+        if (id == null) {
+            return "".hashCode();
+        }
+
+        return id.hashCode();
+    }
+
+    @Override
+    public boolean equals(Object obj) {
+        if (obj == null) {
+            return false;
+        }
+
+        if (!(obj instanceof IgnoredItem)) {
+            return false;
+        }
+
+        if (id == null) {
+            return false;
+        }
+
+        return id.equals(((IgnoredItem)obj).id);
     }
 }

--- a/src/main/java/de/aspera/locapp/dto/IgnoredItem.java
+++ b/src/main/java/de/aspera/locapp/dto/IgnoredItem.java
@@ -16,7 +16,12 @@ import javax.persistence.UniqueConstraint;
     uniqueConstraints = @UniqueConstraint(columnNames = {"ID", "FILE_NAME"})
 )
 public class IgnoredItem implements Serializable {
-    @Id
+    /**
+	 * 
+	 */
+	private static final long serialVersionUID = -4226633978528077781L;
+
+	@Id
     @GeneratedValue
     private String id;
 
@@ -31,7 +36,7 @@ public class IgnoredItem implements Serializable {
         this.id = id;
     }
 
-    @Column(name = "FILE_NAME")
+    @Column(name = "FILE_NAME", unique = true)
     public String getFileName() {
         return fileName;
     }

--- a/src/main/java/de/aspera/locapp/dto/IgnoredItem.java
+++ b/src/main/java/de/aspera/locapp/dto/IgnoredItem.java
@@ -1,0 +1,41 @@
+package de.aspera.locapp.dto;
+
+import java.io.Serializable;
+
+import javax.persistence.Column;
+import javax.persistence.Entity;
+import javax.persistence.GeneratedValue;
+import javax.persistence.Id;
+import javax.persistence.Table;
+import javax.persistence.UniqueConstraint;
+
+@Entity
+@Table(
+    name = "IGNORED_ITEM",
+    uniqueConstraints = @UniqueConstraint(columnNames = {"ID", "FILE_NAME"})
+)
+public class IgnoredItem implements Serializable {
+    @Id
+    @GeneratedValue
+    private String id;
+
+    private String fileName;
+    
+    @Column(name = "ID")
+    public String getId() {
+        return id;
+    }
+
+    public void setId(String id) {
+        this.id = id;
+    }
+
+    @Column(name = "FILE_NAME")
+    public String getFileName() {
+        return fileName;
+    }
+
+    public void setFileName(String fileName) {
+        this.fileName = fileName;
+    }
+}

--- a/src/main/java/de/aspera/locapp/main/MainStart.java
+++ b/src/main/java/de/aspera/locapp/main/MainStart.java
@@ -77,7 +77,7 @@ public class MainStart {
         if (CommandContext.getInstance().isCommand(cmd)) {
             try {
                 CommandContext.getInstance().executeCommand(cmd);
-            } catch (InstantiationException | IllegalAccessException | CommandException e) {
+            } catch (CommandException e) {
                 logger.log(Level.SEVERE, e.getMessage(), e);
             }
         } else {

--- a/src/main/java/de/aspera/locapp/util/HelperUtil.java
+++ b/src/main/java/de/aspera/locapp/util/HelperUtil.java
@@ -3,7 +3,6 @@ package de.aspera.locapp.util;
 import java.nio.file.Paths;
 import java.text.SimpleDateFormat;
 import java.util.Date;
-import java.util.List;
 import java.util.Locale;
 import java.util.Set;
 import java.util.regex.Pattern;

--- a/src/main/java/de/aspera/locapp/util/HelperUtil.java
+++ b/src/main/java/de/aspera/locapp/util/HelperUtil.java
@@ -6,6 +6,7 @@ import java.util.Date;
 import java.util.List;
 import java.util.Locale;
 import java.util.Set;
+import java.util.regex.Pattern;
 
 import org.apache.commons.lang3.StringUtils;
 
@@ -26,10 +27,27 @@ public class HelperUtil {
      * @return
      */
     public static boolean isIgnoredFile(Set<String> ignoredFiles, String filePath) {
-        // TODO: Consider fullPath, fileName and regex
-
         var path = Paths.get(filePath);
-        return ignoredFiles.contains(path.getFileName().toString());
+        var pathAbsolute = path.toAbsolutePath();
+
+        boolean pathComparison = ignoredFiles.stream()
+            .filter(ignoredFile -> !ignoredFile.contains("*"))
+            .map(ignoredFile -> Paths.get(ignoredFile))
+            .anyMatch(ignoredPath -> pathAbsolute.endsWith(ignoredPath.toAbsolutePath()));
+
+        if (pathComparison) {
+            return true;
+        }
+
+        boolean patternComparison = ignoredFiles.stream()
+            .filter(ignoredFile -> ignoredFile.contains("*"))
+            .map(ignoredFile -> ignoredFile.replace("*", "\\w*"))
+            .anyMatch(ignoredFile -> Pattern.compile(ignoredFile)
+                .matcher(path.toString())
+                .find()
+            );
+
+        return patternComparison;
     }
 
     /**

--- a/src/main/java/de/aspera/locapp/util/HelperUtil.java
+++ b/src/main/java/de/aspera/locapp/util/HelperUtil.java
@@ -1,8 +1,11 @@
 package de.aspera.locapp.util;
 
+import java.nio.file.Paths;
 import java.text.SimpleDateFormat;
 import java.util.Date;
+import java.util.List;
 import java.util.Locale;
+import java.util.Set;
 
 import org.apache.commons.lang3.StringUtils;
 
@@ -14,6 +17,20 @@ public class HelperUtil {
 
     private static SimpleDateFormat FILE_TIMESTAMP_SIMPLE_DATE_FORMAT = new SimpleDateFormat(
             FILE_TIMESTAMP_FORMAT);
+
+    /**
+     * Determine if given filePath is ignored.
+     * 
+     * @param ignoredFiles
+     * @param filePath
+     * @return
+     */
+    public static boolean isIgnoredFile(Set<String> ignoredFiles, String filePath) {
+        // TODO: Consider fullPath, fileName and regex
+
+        var path = Paths.get(filePath);
+        return ignoredFiles.contains(path.getFileName().toString());
+    }
 
     /**
      * Get the Locale ident of a property file.

--- a/src/main/resources/META-INF/persistence.xml
+++ b/src/main/resources/META-INF/persistence.xml
@@ -3,6 +3,7 @@
   <persistence-unit name="h2locapp" transaction-type="RESOURCE_LOCAL">
     <provider>org.eclipse.persistence.jpa.PersistenceProvider</provider>
     <class>de.aspera.locapp.dto.Localization</class>
+    <class>de.aspera.locapp.dto.IgnoredItem</class>
     <class>de.aspera.locapp.dto.FileInfo</class>
     <class>de.aspera.locapp.dto.Config</class>
     <properties>


### PR DESCRIPTION
## Feature: Ignored files (blacklist)

### What you need to have
A file with the list of names of the `.property` files that need to be excluded from the translation process.
E.g.:

_.blacklist_
```
test_fr.properties
test_it.properties
```

### How this feature works
- while in command prompt, type `iil <path-to-blacklist-file>` (path can be relative or absolute)
- the command will parse the file and store the entries
- when running `file` command, the files that were listed in blacklist, will not be loaded into the memory, thus, they won't take part in translation process
- to clear the ignore list, type `cil`