### PR TITLE
Feature/Default language selection

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,7 @@ all available * .properties files from a root directory and imports the path and
         (ei)excel-import DIR:                   Import properties from an excel file
         (ed)export-delta DIR:                   Export delta (properties vs. excel) into an excel file
         (id)import-delta DIR VERSION:           Import delta and merge with selected version
+        (sdl)select-default-language LANG:      Set default language for excel export (LANG=[en,de...]).
         (pc)properties-count SRC|XLS [L] [E]:   Count the amount of properties (all or by language ISOCODE[L], search for empty values [E=1])
         (mp)merge-properties SRC|XLS:           All known properties will be merged with their latest version to a new data set.
         (ci)check-integrity [L]:                Check if all SRC properties provided by XLS properties with all or specified languages(all or by language ISOCODE[L]).

--- a/src/main/java/de/aspera/locapp/cmd/CommandContext.java
+++ b/src/main/java/de/aspera/locapp/cmd/CommandContext.java
@@ -92,5 +92,7 @@ public class CommandContext {
         addCommand("merge-properties", MergeCommand.class);
         addCommand("ci", CheckIntegrityCommand.class);
         addCommand("check-integrity", CheckIntegrityCommand.class);
+        addCommand("sdl", SetDefaultLanguageCommand.class);
+        addCommand("set-default-language", SetDefaultLanguageCommand.class);
     }
 }

--- a/src/main/java/de/aspera/locapp/cmd/ExcelExportCommand.java
+++ b/src/main/java/de/aspera/locapp/cmd/ExcelExportCommand.java
@@ -121,8 +121,13 @@ public class ExcelExportCommand implements CommandRunnable {
         } else {
             fileName = HelperUtil.currentTimestamp() + "-export-all.xls";
         }
+        
+        Locale defaultLocale = Locale.ENGLISH;
+        Set<String> fullPaths = locFacade.getFiles(defaultLocale, false);
 
-        Set<String> fullPaths = locFacade.getDefaultFiles(false);
+        if (fullPaths.isEmpty()) {
+            logger.log(Level.SEVERE, "No localization files for the locale [" + defaultLocale.getLanguage() + "].");
+        }
         exportPath += SystemUtils.IS_OS_WINDOWS ? "\\" : "/";
         int rowcount = ROWGAP_HEADER;
 
@@ -149,26 +154,25 @@ public class ExcelExportCommand implements CommandRunnable {
         List<Localization> allLocalizations = locFacade.getLocalizations(lastVersion, Status.SRC, false, null);
 
         for (String fullPath : fullPaths) {
-            for (Localization savedLocalizationEN : locFacade.getLocalizations(lastVersion, Status.SRC, false,
+            for (Localization savedDefLocalization : locFacade.getLocalizations(lastVersion, Status.SRC, false,
                     fullPath)) {
                 int cell = 0;
                 Row row = sheets.get(0).createRow(rowcount++);
-                row.createCell(cell++).setCellValue(savedLocalizationEN.getFileName());
-                row.createCell(cell++).setCellValue(savedLocalizationEN.getKey());
+                row.createCell(cell++).setCellValue(savedDefLocalization.getFileName());
+                row.createCell(cell++).setCellValue(savedDefLocalization.getKey());
                 if (StringUtils.isEmpty(language)) {
                     for (String lang : knownLanguages) {
                         if (lang.equals(Locale.ENGLISH.toString())) {
                             Cell valueCell = row.createCell(cell++);
-                            if (savedLocalizationEN.getValue().equals(EMPTY_VALUE)) {
+                            if (savedDefLocalization.getValue().equals(EMPTY_VALUE)) {
                                 valueCell.setCellStyle(styleMap.get(STYLE_YELLOW));
                             }
-                            // default EN
-                            valueCell.setCellValue(savedLocalizationEN.getValue());
+                            valueCell.setCellValue(savedDefLocalization.getValue());
                         } else {
                             Cell valueCell = row.createCell(cell++);
                             Localization localization = getLoc(allLocalizations,
-                                    HelperUtil.replaceLanguageFromPath(savedLocalizationEN.getFullPath(), lang),
-                                    savedLocalizationEN.getKey(), null);
+                                    HelperUtil.replaceLanguageFromPath(savedDefLocalization.getFullPath(), lang),
+                                    savedDefLocalization.getKey(), null);
                             if (localization.getValue().equals(EMPTY_VALUE)) {
                                 valueCell.setCellStyle(styleMap.get(STYLE_YELLOW));
                             }
@@ -178,13 +182,13 @@ public class ExcelExportCommand implements CommandRunnable {
                 } else {
                     Localization localization = null;
                     Cell valueCell = row.createCell(cell++);
-                    if (!language.equalsIgnoreCase(Locale.ENGLISH.toString())) {
+                    if (!language.equalsIgnoreCase(defaultLocale.toString())) {
                         localization = getLoc(allLocalizations,
-                                HelperUtil.replaceLanguageFromPath(savedLocalizationEN.getFullPath(), language),
-                                savedLocalizationEN.getKey(), language);
+                                HelperUtil.replaceLanguageFromPath(savedDefLocalization.getFullPath(), language),
+                                savedDefLocalization.getKey(), language);
 
-                        Localization enDefaultLoc = getLoc(allLocalizations, savedLocalizationEN.getFullPath(),
-                                savedLocalizationEN.getKey(), Locale.ENGLISH.getLanguage());
+                        Localization defaultLocalization = getLoc(allLocalizations, savedDefLocalization.getFullPath(),
+                                savedDefLocalization.getKey(), defaultLocale.getLanguage());
 
                         if (emptyProperties && !localization.getValue().equals(EMPTY_VALUE)) {
                             sheets.get(0).removeRow(row);
@@ -193,24 +197,24 @@ public class ExcelExportCommand implements CommandRunnable {
                         }
                         if (localization.getValue().equals(EMPTY_VALUE)) {
                             valueCell.setCellStyle(styleMap.get(STYLE_YELLOW));
-                            valueCell.setCellValue("[en]" + enDefaultLoc.getValue());
+                            valueCell.setCellValue("[" + defaultLocale.getLanguage() + "]" + defaultLocalization.getValue());
                         } else {
                             valueCell.setCellValue(localization.getValue());
                         }
 
                     } else {
-                        if (emptyProperties && !savedLocalizationEN.getValue().equals(EMPTY_VALUE)) {
+                        if (emptyProperties && !savedDefLocalization.getValue().equals(EMPTY_VALUE)) {
                             sheets.get(0).removeRow(row);
                             rowcount--;
                             continue;
                         }
-                        if (savedLocalizationEN.getValue().equals(EMPTY_VALUE)) {
+                        if (savedDefLocalization.getValue().equals(EMPTY_VALUE)) {
                             valueCell.setCellStyle(styleMap.get(STYLE_YELLOW));
                         }
-                        valueCell.setCellValue(savedLocalizationEN.getValue());
+                        valueCell.setCellValue(savedDefLocalization.getValue());
                     }
                 }
-                row.createCell(cell++).setCellValue(savedLocalizationEN.getFullPath());
+                row.createCell(cell++).setCellValue(savedDefLocalization.getFullPath());
             }
         }
 

--- a/src/main/java/de/aspera/locapp/cmd/ExcelExportCommand.java
+++ b/src/main/java/de/aspera/locapp/cmd/ExcelExportCommand.java
@@ -29,6 +29,7 @@ import org.apache.poi.ss.usermodel.HorizontalAlignment;
 import org.apache.poi.ss.usermodel.Row;
 import org.apache.poi.ss.usermodel.Sheet;
 
+import de.aspera.locapp.dao.ConfigFacade;
 import de.aspera.locapp.dao.DatabaseException;
 import de.aspera.locapp.dao.LocalizationFacade;
 import de.aspera.locapp.dto.Localization;
@@ -42,6 +43,7 @@ public class ExcelExportCommand implements CommandRunnable {
     private static final int       ROWGAP_HEADER = 0;
     private static final Logger    logger        = Logger.getLogger(ExcelExportCommand.class.getName());
     private LocalizationFacade     locFacade     = new LocalizationFacade();
+    private ConfigFacade           configFacade  = new ConfigFacade();
     private Map<String, CellStyle> styleMap      = new HashMap<>();
     private String                 fileName;
 
@@ -123,6 +125,11 @@ public class ExcelExportCommand implements CommandRunnable {
         }
         
         Locale defaultLocale = Locale.ENGLISH;
+        
+        if (language != null) {
+            defaultLocale = new Locale(configFacade.getDefaultLanguage());
+        }
+
         Set<String> fullPaths = locFacade.getFiles(defaultLocale, false);
 
         if (fullPaths.isEmpty()) {

--- a/src/main/java/de/aspera/locapp/cmd/ExportPropertiesCommand.java
+++ b/src/main/java/de/aspera/locapp/cmd/ExportPropertiesCommand.java
@@ -55,7 +55,7 @@ public class ExportPropertiesCommand implements CommandRunnable {
 
 		try {
 			allLocalizations = locFacade.getLocalizations(locFacade.lastVersion(Status.XLS), Status.XLS, false, null);
-			Set<String> defaultPathFiles = locFacade.getDefaultFiles(true);
+			Set<String> defaultPathFiles = locFacade.getFiles(Locale.ENGLISH, true);
 			List<String> languages = locFacade.getLanguages(true);
 
 			for (String defaultPathFile : defaultPathFiles) {

--- a/src/main/java/de/aspera/locapp/cmd/HelpCommand.java
+++ b/src/main/java/de/aspera/locapp/cmd/HelpCommand.java
@@ -12,6 +12,7 @@ public class HelpCommand implements CommandRunnable {
         System.out.println("\t(ei)excel-import DIR: \t\t\tImport properties from an excel file");
         System.out.println("\t(ed)export-delta DIR: \t\t\tExport delta (properties vs. excel) into an excel file");
         System.out.println("\t(id)import-delta DIR VERSION: \t\tImport delta and merge with selected version");
+        System.out.println("\t(sdl)select-default-language LANG: \tSet default language for excel export (LANG=[en,de...]).");
         System.out.println("\t(pc)properties-count SRC|XLS [L] [E]: \tCount the amount of properties (all or by language ISOCODE[L], search for empty values [E=1])");
         System.out.println("\t(mp)merge-properties SRC|XLS: \t\tAll known properties will be merged with their latest version to a new data set.");
         System.out.println("\t(ci)check-integrity [L]: \t\tCheck if all SRC properties provided by XLS properties with all or specified languages(all or by language ISOCODE[L]).");

--- a/src/main/java/de/aspera/locapp/cmd/SetDefaultLanguageCommand.java
+++ b/src/main/java/de/aspera/locapp/cmd/SetDefaultLanguageCommand.java
@@ -1,0 +1,40 @@
+package de.aspera.locapp.cmd;
+
+import java.util.Locale;
+import java.util.MissingResourceException;
+import java.util.logging.Level;
+import java.util.logging.Logger;
+
+import de.aspera.locapp.dao.ConfigFacade;
+import de.aspera.locapp.dao.DatabaseException;
+
+public class SetDefaultLanguageCommand implements CommandRunnable {
+    private ConfigFacade configFacade = new ConfigFacade();
+    private Logger logger = Logger.getLogger(SetDefaultLanguageCommand.class.getName());
+
+    @Override
+    public void run() {
+        try {
+            setDefaultLanguage();
+        } catch (DatabaseException | CommandException e) {
+            logger.log(Level.SEVERE, e.getMessage(), e);
+        }
+    }
+
+    private void setDefaultLanguage() 
+        throws CommandException, DatabaseException {
+        var language = CommandContext.getInstance()
+            .nextArgument()
+            .toLowerCase();
+
+        var locale = new Locale(language);
+
+		try {
+			locale.getISO3Language();
+		} catch (MissingResourceException e) {
+			throw new CommandException("Language [" + language + "] is invalid");
+		}
+
+        configFacade.setDefaultLanguage(locale);
+    }
+}

--- a/src/main/java/de/aspera/locapp/dao/LocalizationFacade.java
+++ b/src/main/java/de/aspera/locapp/dao/LocalizationFacade.java
@@ -11,6 +11,7 @@ import java.util.Locale;
 import java.util.Set;
 import java.util.logging.Level;
 import java.util.logging.Logger;
+import java.util.stream.Collectors;
 
 import javax.persistence.Query;
 
@@ -167,7 +168,7 @@ public class LocalizationFacade extends AbstractFacade<Localization> {
 
     }
 
-    public Set<String> getDefaultFiles(boolean exportProperties) throws DatabaseException {
+    public Set<String> getFiles(Locale locale, boolean exportProperties) throws DatabaseException {
         try {
             String queryStr = "select distinct target.fullPath from " + Localization.class.getSimpleName()
                     + " target where target.fullPath LIKE :fullPath ";
@@ -182,17 +183,11 @@ public class LocalizationFacade extends AbstractFacade<Localization> {
             }
             	
             @SuppressWarnings("unchecked")
-			List<String> fullPaths = (List<String>) query.getResultList();
-            Set<String> paths = new HashSet<>();
-            for (String path : fullPaths) {
-                if (HelperUtil.getLocaleFromPropertyFile(path).equals(Locale.ENGLISH.toString())) {
-                    paths.add(path);
-                } else {
-                	paths.add(HelperUtil.removeLanguageFromPath(path));
-                }
-            }
+            List<String> fullPaths = (List<String>) query.getResultList();
             
-            return paths;
+            return fullPaths.stream()
+                .filter(path -> HelperUtil.getLocaleFromPropertyFile(path).equals(locale.toString()))
+                .collect(Collectors.toSet());
         } catch (Exception e) {
             throw new DatabaseException(e.getMessage(), e);
         }


### PR DESCRIPTION
## Feature: Default language selection

### How this feature works
- while in command prompt type `sdl <language>` (e.g.  `sdl de`)
- when running `ee` command with specified target language, the default language will be considered for the template translations